### PR TITLE
Save tokens in cookies

### DIFF
--- a/app.py
+++ b/app.py
@@ -123,6 +123,7 @@ def get_data():
                 raise ValueError("Wrong domain: {}".format(idinfo["hd"]))
             sessions.add_token(token)
         except ValueError as e:
+            # Be careful changing. This is a magic string for the front end
             return "Bad token: {}".format(e), 401
     try:
         with open("data.json") as f:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "^4.4.1",
     "bootstrap-autocomplete": "https://github.com/MuddCreates/bootstrap-autocomplete#hack/life-after-mudd",
     "jquery": "^3.4.1",
+    "js-cookie": "^2.2.1",
     "latinize": "^0.4.1",
     "mapbox-gl": "^1.7.0",
     "parcel-bundler": "^1.12.4",

--- a/sessions.py
+++ b/sessions.py
@@ -3,15 +3,6 @@ import sys
 
 import redis
 
-# Each time an OAuth token is issued to the same user, the last few
-# characters in the token change because they represent a hash which
-# differs for each issuance. We want to use OAuth tokens as a way to
-# identify when we are seeing the same user more than once, so we
-# employ the following disgusting hack to just restrict our attention
-# to the part of the token that doesn't change. This variable holds
-# the length of the prefix that we consider.
-PREFIX_LENGTH = 475
-
 # Redis key used to store the set of known-good tokens.
 SET_NAME = "TOKENS"
 
@@ -39,11 +30,11 @@ else:
 
 def add_token(token, expiration_seconds=OAUTH_CACHE_TIMEOUT):
     if r:
-        r.sadd(SET_NAME, token[:PREFIX_LENGTH])
+        r.sadd(SET_NAME, token)
 
 
 def check_token(token):
     if r:
-        return r.sismember(SET_NAME, token[:PREFIX_LENGTH])
+        return r.sismember(SET_NAME, token)
     else:
         return False

--- a/static/js/index/api.js
+++ b/static/js/index/api.js
@@ -45,12 +45,12 @@ function cleanResponses(responses) {
 export const fetchAction = thunk(async (dispatch) => {
   dispatch({ type: "FETCHING_DATA" });
 
-  // Skip getting Oauth token if it is already stored as a cookie
+  // Skip getting OAuth token if it is already stored as a cookie
   let oauthToken = Cookies.get("oauthToken");
   if (oauthToken === undefined) {
     const GoogleAuth = gapi.auth2.getAuthInstance();
     oauthToken = GoogleAuth.currentUser.get().getAuthResponse().id_token;
-    // Oauth tokens are persisted in cookies for one month
+    // OAuth tokens are persisted in cookies for one month
     Cookies.set("oauthToken", oauthToken, { expires: 31 });
   }
   const response = await fetch("/api/v1/data", {

--- a/static/js/index/api.js
+++ b/static/js/index/api.js
@@ -1,7 +1,8 @@
 "use strict";
 
-import { thunk } from "./util";
 import Cookies from "js-cookie";
+
+import { thunk } from "./util";
 import { oauthSetupAction } from "./oauth";
 
 // Given a latitude and longitude (in reverse order), where both

--- a/static/js/index/api.js
+++ b/static/js/index/api.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import { thunk } from "./util";
-import Cookies from 'js-cookie';
+import Cookies from "js-cookie";
 import { oauthSetupAction } from "./oauth";
 
 // Given a latitude and longitude (in reverse order), where both
@@ -45,13 +45,13 @@ export const fetchAction = thunk(async (dispatch) => {
   dispatch({ type: "FETCHING_DATA" });
 
   // Skip getting Oauth token if it is already stored as a cookie
-  let oauthToken = Cookies.get('oauthToken');
-    if (oauthToken === undefined) {
-        const GoogleAuth = gapi.auth2.getAuthInstance();
-        oauthToken = GoogleAuth.currentUser.get().getAuthResponse().id_token;
-        // Oauth tokens are persisted in cookies for one month
-        Cookies.set('oauthToken', oauthToken, {expires: 31});
-    }
+  let oauthToken = Cookies.get("oauthToken");
+  if (oauthToken === undefined) {
+    const GoogleAuth = gapi.auth2.getAuthInstance();
+    oauthToken = GoogleAuth.currentUser.get().getAuthResponse().id_token;
+    // Oauth tokens are persisted in cookies for one month
+    Cookies.set("oauthToken", oauthToken, { expires: 31 });
+  }
   const response = await fetch("/api/v1/data", {
     method: "POST",
     headers: {
@@ -72,14 +72,13 @@ export const fetchAction = thunk(async (dispatch) => {
     }
 
     // Handle a bad oauth token saved locally by deleting the cookie and rerunning the oauthSetupAction phase
-    if (explanation === ": Bad token: Could not verify token signature."){
-      Cookies.remove('oauthToken');
+    if (explanation === ": Bad token: Could not verify token signature.") {
+      Cookies.remove("oauthToken");
       dispatch(oauthSetupAction);
     } else {
       throw new Error(`Got status ${response.status} from API` + explanation);
     }
-  }
-  else {
+  } else {
     const responses = cleanResponses(await response.json());
     dispatch({
       type: "SHOW_DATA",

--- a/static/js/index/api.js
+++ b/static/js/index/api.js
@@ -2,8 +2,8 @@
 
 import Cookies from "js-cookie";
 
-import { thunk } from "./util";
 import { oauthSetupAction } from "./oauth";
+import { thunk } from "./util";
 
 // Given a latitude and longitude (in reverse order), where both
 // values are strings, parse them into floats and return an object

--- a/static/js/index/api.js
+++ b/static/js/index/api.js
@@ -72,10 +72,11 @@ export const fetchAction = thunk(async (dispatch) => {
       // don't need it anyway.
     }
 
-    // Handle a bad OAuth token saved locally by deleting the cookie
-    // and rerunning the oauthSetupAction phase
+    // Delete OAuth token in case it caused the error
+    Cookies.remove("oauthToken");
+
+    // Handle a bad OAuth token cookie by rerunning the oauthSetupAction phase
     if (explanation.startsWith(": Bad token")) {
-      Cookies.remove("oauthToken");
       dispatch(oauthSetupAction);
     } else {
       throw new Error(`Got status ${response.status} from API` + explanation);

--- a/static/js/index/api.js
+++ b/static/js/index/api.js
@@ -64,8 +64,10 @@ export const fetchAction = thunk(async (dispatch) => {
   });
   if (!response.ok) {
     let explanation = "";
+    let err = null;
     try {
-      explanation = ": " + (await response.text());
+      err = await response.text();
+      explanation = ": " + err;
     } catch (e) {
       // If stream is interrupted, forget about getting an
       // explanation. Who does that server think it is, anyway? We
@@ -76,7 +78,7 @@ export const fetchAction = thunk(async (dispatch) => {
     Cookies.remove("oauthToken");
 
     // Handle a bad OAuth token cookie by rerunning the oauthSetupAction phase
-    if (explanation.startsWith(": Bad token")) {
+    if (err.startsWith("Bad token")) {
       dispatch(oauthSetupAction);
     } else {
       throw new Error(`Got status ${response.status} from API` + explanation);

--- a/static/js/index/api.js
+++ b/static/js/index/api.js
@@ -72,8 +72,9 @@ export const fetchAction = thunk(async (dispatch) => {
       // don't need it anyway.
     }
 
-    // Handle a bad oauth token saved locally by deleting the cookie and rerunning the oauthSetupAction phase
-    if (explanation === ": Bad token: Could not verify token signature.") {
+    // Handle a bad OAuth token saved locally by deleting the cookie
+    // and rerunning the oauthSetupAction phase
+    if (explanation.startsWith(": Bad token")) {
       Cookies.remove("oauthToken");
       dispatch(oauthSetupAction);
     } else {

--- a/static/js/index/oauth.js
+++ b/static/js/index/oauth.js
@@ -1,8 +1,9 @@
 "use strict";
 
+import Cookies from "js-cookie";
+
 import { fetchAction } from "./api";
 import { thunk } from "./util";
-import Cookies from "js-cookie";
 
 // Check if the session is currently authenticated with the necessary
 // permissions. If it is and the UI is currently in an OAuth state,

--- a/static/js/index/oauth.js
+++ b/static/js/index/oauth.js
@@ -2,7 +2,7 @@
 
 import { fetchAction } from "./api";
 import { thunk } from "./util";
-import Cookies from 'js-cookie';
+import Cookies from "js-cookie";
 
 // Check if the session is currently authenticated with the necessary
 // permissions. If it is and the UI is currently in an OAuth state,
@@ -14,7 +14,7 @@ const oauthCheckAuthAction = thunk((dispatch) => {
   dispatch({ type: "VERIFYING_OAUTH" });
 
   // Only get auth instances if oauth token isn't in cookie
-  if (Cookies.get('oauthToken') === undefined){
+  if (Cookies.get("oauthToken") === undefined) {
     const GoogleAuth = gapi.auth2.getAuthInstance();
     if (GoogleAuth.currentUser.get().hasGrantedScopes("email")) {
       dispatch(fetchAction);
@@ -33,21 +33,20 @@ export const oauthSetupAction = thunk(async (dispatch) => {
   dispatch({ type: "VERIFYING_OAUTH" });
 
   // Only get auth instances if oauth token isn't in cookie
-  if (Cookies.get('oauthToken') === undefined){
-      // https://developers.google.com/identity/protocols/OAuth2UserAgent
-      await new Promise((resolve) => gapi.load("client:auth2", resolve));
-      await gapi.client.init({
-          clientId:
-          "548868103597-3th6ihbnejkscon1950m9mm31misvhk9.apps.googleusercontent.com",
-          scope: "email",
-      });
-      const GoogleAuth = gapi.auth2.getAuthInstance();
-      GoogleAuth.isSignedIn.listen(() => dispatch(oauthCheckAuthAction));
-      dispatch(oauthCheckAuthAction);
+  if (Cookies.get("oauthToken") === undefined) {
+    // https://developers.google.com/identity/protocols/OAuth2UserAgent
+    await new Promise((resolve) => gapi.load("client:auth2", resolve));
+    await gapi.client.init({
+      clientId:
+        "548868103597-3th6ihbnejkscon1950m9mm31misvhk9.apps.googleusercontent.com",
+      scope: "email",
+    });
+    const GoogleAuth = gapi.auth2.getAuthInstance();
+    GoogleAuth.isSignedIn.listen(() => dispatch(oauthCheckAuthAction));
+    dispatch(oauthCheckAuthAction);
   } else {
-      dispatch(oauthCheckAuthAction);
+    dispatch(oauthCheckAuthAction);
   }
-
 });
 
 // Start the OAuth login flow, and update the UI to have some helpful

--- a/static/js/index/oauth.js
+++ b/static/js/index/oauth.js
@@ -14,7 +14,7 @@ import { thunk } from "./util";
 const oauthCheckAuthAction = thunk((dispatch) => {
   dispatch({ type: "VERIFYING_OAUTH" });
 
-  // Only get auth instances if oauth token isn't in cookie
+  // Only get auth instances if OAuth token isn't in cookie
   if (Cookies.get("oauthToken") === undefined) {
     const GoogleAuth = gapi.auth2.getAuthInstance();
     if (GoogleAuth.currentUser.get().hasGrantedScopes("email")) {
@@ -33,7 +33,7 @@ const oauthCheckAuthAction = thunk((dispatch) => {
 export const oauthSetupAction = thunk(async (dispatch) => {
   dispatch({ type: "VERIFYING_OAUTH" });
 
-  // Only get auth instances if oauth token isn't in cookie
+  // Only get auth instances if OAuth token isn't in cookie
   if (Cookies.get("oauthToken") === undefined) {
     // https://developers.google.com/identity/protocols/OAuth2UserAgent
     await new Promise((resolve) => gapi.load("client:auth2", resolve));

--- a/static/js/index/oauth.js
+++ b/static/js/index/oauth.js
@@ -2,6 +2,7 @@
 
 import { fetchAction } from "./api";
 import { thunk } from "./util";
+import Cookies from 'js-cookie';
 
 // Check if the session is currently authenticated with the necessary
 // permissions. If it is and the UI is currently in an OAuth state,
@@ -11,11 +12,17 @@ import { thunk } from "./util";
 // OAuth flow.
 const oauthCheckAuthAction = thunk((dispatch) => {
   dispatch({ type: "VERIFYING_OAUTH" });
-  const GoogleAuth = gapi.auth2.getAuthInstance();
-  if (GoogleAuth.currentUser.get().hasGrantedScopes("email")) {
-    dispatch(fetchAction);
+
+  // Only get auth instances if oauth token isn't in cookie
+  if (Cookies.get('oauthToken') === undefined){
+    const GoogleAuth = gapi.auth2.getAuthInstance();
+    if (GoogleAuth.currentUser.get().hasGrantedScopes("email")) {
+      dispatch(fetchAction);
+    } else {
+      dispatch({ type: "PROMPT_FOR_LOGIN" });
+    }
   } else {
-    dispatch({ type: "PROMPT_FOR_LOGIN" });
+    dispatch(fetchAction);
   }
 });
 
@@ -24,16 +31,23 @@ const oauthCheckAuthAction = thunk((dispatch) => {
 // in.
 export const oauthSetupAction = thunk(async (dispatch) => {
   dispatch({ type: "VERIFYING_OAUTH" });
-  // https://developers.google.com/identity/protocols/OAuth2UserAgent
-  await new Promise((resolve) => gapi.load("client:auth2", resolve));
-  await gapi.client.init({
-    clientId:
-      "548868103597-3th6ihbnejkscon1950m9mm31misvhk9.apps.googleusercontent.com",
-    scope: "email",
-  });
-  const GoogleAuth = gapi.auth2.getAuthInstance();
-  GoogleAuth.isSignedIn.listen(() => dispatch(oauthCheckAuthAction));
-  dispatch(oauthCheckAuthAction);
+
+  // Only get auth instances if oauth token isn't in cookie
+  if (Cookies.get('oauthToken') === undefined){
+      // https://developers.google.com/identity/protocols/OAuth2UserAgent
+      await new Promise((resolve) => gapi.load("client:auth2", resolve));
+      await gapi.client.init({
+          clientId:
+          "548868103597-3th6ihbnejkscon1950m9mm31misvhk9.apps.googleusercontent.com",
+          scope: "email",
+      });
+      const GoogleAuth = gapi.auth2.getAuthInstance();
+      GoogleAuth.isSignedIn.listen(() => dispatch(oauthCheckAuthAction));
+      dispatch(oauthCheckAuthAction);
+  } else {
+      dispatch(oauthCheckAuthAction);
+  }
+
 });
 
 // Start the OAuth login flow, and update the UI to have some helpful

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,6 +3563,11 @@ jquery@^3.4.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"


### PR DESCRIPTION
Saves the oauth token in a cookie for a month after successfully creating it so we can avoid slow startup in the future. Redis now stores the whole cookie instead  of some prefix since we normally won't actually regenerate the token each time the user joins. Additionally if there is an oauth error from failed token verification, we delete the saved token and try to regenerate one.

I'm not 100% sure you will like my approach to error handling for 2 reasons: 1. Haven't used redux before. Not sure if dispatching to `oauthSetupAction` is the elegant thing to do 2. It could be brittle to look for the specific error message that google oauth implementation returns on an invalid token, but I didn't want to catch all 401 error either in case something else could be the reason it was thrown.