### PR TITLE
Additional sidebar views

### DIFF
--- a/static/js/index/components/MapView.js
+++ b/static/js/index/components/MapView.js
@@ -11,6 +11,7 @@ import { sidebarWidthFraction } from "../config";
 import { tagAll } from "../tag";
 import { store } from "../redux";
 import { GeotagView } from "../state";
+import { SidebarView } from "../state";
 
 const CIRCLE_RADIUS = 10;
 const HIGHLIGHT_BBOX_RADIUS = 10;
@@ -183,6 +184,7 @@ class MapView extends React.Component {
         store.dispatch({
           type: "SHOW_DETAILS",
           responses: Array.from(nearbyPoints),
+          sidebarView: SidebarView.summaryView,
         });
       } else {
         store.dispatch({

--- a/static/js/index/components/SearchBar.js
+++ b/static/js/index/components/SearchBar.js
@@ -16,6 +16,7 @@ require("bootstrap-autocomplete");
 import { failHard } from "../error";
 import { tagAll } from "../tag";
 import { store } from "../redux";
+import { SidebarView } from "../state";
 
 const statesByName = {};
 const statesByAbbr = {};
@@ -153,6 +154,7 @@ function doSearch(query, index) {
   store.dispatch({
     type: "SHOW_DETAILS",
     responses: index.get(query).map((resp) => resp.idx),
+    sidebarView: SidebarView.summaryView,
   });
   store.dispatch({
     type: "UPDATE_MAP_VIEW_ZOOM",

--- a/static/js/index/components/Sidebar.js
+++ b/static/js/index/components/Sidebar.js
@@ -64,7 +64,7 @@ function createTwoLevelViewJSX(taggedData, firstKeyView, secondKeyView, firstGro
     });
   };
   return (
-          {groupedData.map(({ firstKey, secondKeys}, idx) => (
+          groupedData.map(({ firstKey, secondKeys}, idx) => (
             <Fragment key={idx}>
               <h5 onClick={() => firstKeyAction(secondKeys)}>
                 <b>{firstKey}</b>
@@ -88,7 +88,7 @@ function createTwoLevelViewJSX(taggedData, firstKeyView, secondKeyView, firstGro
                 </Fragment>
               ))}
             </Fragment>
-          ))}
+          ))
   );
 }
 
@@ -150,18 +150,12 @@ class Sidebar extends React.Component {
       });
     }
 
+    let sidebarBody = null;
     if (this.props.sidebarView === SidebarView.detailView){
       const subject = tag(this.props.responses[0], this.props.geotagView);
-      return (
-          <div
-        style={style}
-          >
-          {describeSubject(subject)}
-        </div>
-      );
+      sidebarBody = describeSubject(subject);
     } else {
       // for all view made with createTwoLevelViewJSX
-      let sidebarBody = null;
       switch (this.props.sidebarView){
       case SidebarView.summaryView:
         sidebarBody = createTwoLevelViewJSX(taggedData, SidebarView.summaryView, SidebarView.organizationView, resp => resp.tag.loc, resp => resp.tag.desc);

--- a/static/js/index/components/Sidebar.js
+++ b/static/js/index/components/Sidebar.js
@@ -14,7 +14,11 @@ import {
   originalWindowHeight,
 } from "../util";
 
-function groupPlansConfigurable(responses, getFirstGroupKey, getSecondGroupKey) {
+function groupPlansConfigurable(
+  responses,
+  getFirstGroupKey,
+  getSecondGroupKey,
+) {
   const index = {};
   for (const resp of responses) {
     const firstGroupKey = getFirstGroupKey(resp);
@@ -34,18 +38,31 @@ function groupPlansConfigurable(responses, getFirstGroupKey, getSecondGroupKey) 
       firstKey,
       secondKeys: Object.keys(index[firstKey])
         .sort()
-        .map((secondKey) => ({ secondKey, responses: index[firstKey][secondKey] })),
+        .map((secondKey) => ({
+          secondKey,
+          responses: index[firstKey][secondKey],
+        })),
     }));
 }
 
-function createTwoLevelViewJSX(taggedData, firstKeyView, secondKeyView, firstGroupBy, secondGroupBy){
+function createTwoLevelViewJSX(
+  taggedData,
+  firstKeyView,
+  secondKeyView,
+  firstGroupBy,
+  secondGroupBy,
+) {
   const groupedData = groupPlansConfigurable(
-    taggedData, firstGroupBy, secondGroupBy,
+    taggedData,
+    firstGroupBy,
+    secondGroupBy,
   );
   const firstKeyAction = (secondKeys) => {
     store.dispatch({
       type: "SHOW_DETAILS",
-      responses: secondKeys.flatMap(item => item.responses.map(resp => resp.idx)),
+      responses: secondKeys.flatMap((item) =>
+        item.responses.map((resp) => resp.idx),
+      ),
       sidebarView: firstKeyView,
     });
     store.dispatch({
@@ -56,57 +73,62 @@ function createTwoLevelViewJSX(taggedData, firstKeyView, secondKeyView, firstGro
   const secondKeyAction = (responses) => {
     store.dispatch({
       type: "SHOW_DETAILS",
-      responses: responses.map(resp => resp.idx),
+      responses: responses.map((resp) => resp.idx),
       sidebarView: secondKeyView,
     });
     store.dispatch({
       type: "UPDATE_MAP_VIEW_ZOOM",
     });
   };
-  return (
-          groupedData.map(({ firstKey, secondKeys}, idx) => (
-            <Fragment key={idx}>
-              <h5 onClick={() => firstKeyAction(secondKeys)}>
-                <b>{firstKey}</b>
-              </h5>
-              {secondKeys.map(({ secondKey, responses }, idx) => (
-                <Fragment key={idx}>
-                  <b onClick={()=>secondKeyAction(responses)}>{secondKey}</b>
-                  {responses.map((resp, idx) => (
-                      <div
-                    key={idx}
-                    onClick={
-                      () => {
-                        store.dispatch({
-                        type: "SHOW_DETAILS",
-                        responses: [resp.idx],
-                          sidebarView: SidebarView.detailView,
-                        });
-                      }
-                    }>{resp.name || "Anonymous"}</div>
-                  ))}
-                </Fragment>
-              ))}
-            </Fragment>
-          ))
-  );
+  return groupedData.map(({ firstKey, secondKeys }, idx) => (
+    <Fragment key={idx}>
+      <h5 onClick={() => firstKeyAction(secondKeys)}>
+        <b>{firstKey}</b>
+      </h5>
+      {secondKeys.map(({ secondKey, responses }, idx) => (
+        <Fragment key={idx}>
+          <b onClick={() => secondKeyAction(responses)}>{secondKey}</b>
+          {responses.map((resp, idx) => (
+            <div
+              key={idx}
+              onClick={() => {
+                store.dispatch({
+                  type: "SHOW_DETAILS",
+                  responses: [resp.idx],
+                  sidebarView: SidebarView.detailView,
+                });
+              }}
+            >
+              {resp.name || "Anonymous"}
+            </div>
+          ))}
+        </Fragment>
+      ))}
+    </Fragment>
+  ));
 }
 
-function describeSubject(taggedSubject){
+function describeSubject(taggedSubject) {
   let fields = [];
-  if(taggedSubject.tag.desc && taggedSubject.tag.loc){
-    fields.push(<div>{taggedSubject.tag.desc} in {taggedSubject.tag.loc}</div>);
+  if (taggedSubject.tag.desc && taggedSubject.tag.loc) {
+    fields.push(
+      <div>
+        {taggedSubject.tag.desc} in {taggedSubject.tag.loc}
+      </div>,
+    );
   }
   if (taggedSubject.major) {
     fields.push(<div>Majored in {taggedSubject.major}</div>);
   }
-  if (taggedSubject.comments){
+  if (taggedSubject.comments) {
     fields.push(<div>Note: {taggedSubject.comments}</div>);
   }
   // TODO: Figure out how to cleanly add keys to fields elements
   return (
-      <div>
-      <h5><b> {taggedSubject.name}</b></h5>
+    <div>
+      <h5>
+        <b> {taggedSubject.name}</b>
+      </h5>
       {fields}
     </div>
   );
@@ -117,7 +139,9 @@ class Sidebar extends React.Component {
     let sidebarContent = null;
     const taggedData = tagAll(this.props.responses, this.props.geotagView);
     let groupedData = groupPlansConfigurable(
-      tagAll(this.props.responses, this.props.geotagView), resp => resp.tag.loc, resp => resp.tag.desc,
+      tagAll(this.props.responses, this.props.geotagView),
+      (resp) => resp.tag.loc,
+      (resp) => resp.tag.desc,
     );
     const style = {
       position: "absolute",
@@ -151,28 +175,35 @@ class Sidebar extends React.Component {
     }
 
     let sidebarBody = null;
-    if (this.props.sidebarView === SidebarView.detailView){
+    if (this.props.sidebarView === SidebarView.detailView) {
       const subject = tag(this.props.responses[0], this.props.geotagView);
       sidebarBody = describeSubject(subject);
     } else {
       // for all view made with createTwoLevelViewJSX
-      switch (this.props.sidebarView){
-      case SidebarView.summaryView:
-        sidebarBody = createTwoLevelViewJSX(taggedData, SidebarView.summaryView, SidebarView.organizationView, resp => resp.tag.loc, resp => resp.tag.desc);
-        break;
+      switch (this.props.sidebarView) {
+        case SidebarView.summaryView:
+          sidebarBody = createTwoLevelViewJSX(
+            taggedData,
+            SidebarView.summaryView,
+            SidebarView.organizationView,
+            (resp) => resp.tag.loc,
+            (resp) => resp.tag.desc,
+          );
+          break;
 
-      case SidebarView.organizationView:
-        sidebarBody = createTwoLevelViewJSX(taggedData, SidebarView.organizationView, SidebarView.summaryView, resp => resp.tag.desc, resp => resp.tag.loc);
-        break;
+        case SidebarView.organizationView:
+          sidebarBody = createTwoLevelViewJSX(
+            taggedData,
+            SidebarView.organizationView,
+            SidebarView.summaryView,
+            (resp) => resp.tag.desc,
+            (resp) => resp.tag.loc,
+          );
+          break;
       }
     }
-    return (
-        <div style={style}>
-        {sidebarBody}
-        </div>
-    );
-  };
-
+    return <div style={style}>{sidebarBody}</div>;
+  }
 }
 
 export default connect((state) => {

--- a/static/js/index/state.js
+++ b/static/js/index/state.js
@@ -19,6 +19,13 @@ export const GeotagView = Object.freeze({
   summer: "summer",
 });
 
+export const SidebarView = Object.freeze({
+  // Show results grouped by location, then company
+  summaryView: "summaryView",
+  // Show detailed info about a particular person
+  detailView: "detailView",
+})
+
 // Initial state for the Redux store. Covers the whole app.
 export const initialState = {
   // Whether a loading indicator should be shown, and if so what the
@@ -32,6 +39,8 @@ export const initialState = {
   // List of objects. As retrieved from the API, with some minor
   // touch-ups. Each object has an idx key which can be used as a uid.
   responses: null,
+  // What info is shown in the sidebar
+  sidebarView: SidebarView.summaryView,
   // Whether to give precedence to summer plans or next-year plans in
   // map and detail views.
   geotagView: GeotagView.standard,
@@ -74,6 +83,7 @@ export const reducer = (state = initialState, action) => {
       return {
         ...state,
         displayedResponses: action.responses,
+        sidebarView: action.sidebarView,
       };
     case "HIDE_DETAILS":
       return {

--- a/static/js/index/state.js
+++ b/static/js/index/state.js
@@ -20,10 +20,12 @@ export const GeotagView = Object.freeze({
 });
 
 export const SidebarView = Object.freeze({
-  // Show results grouped by location, then company
+  // Show results grouped by location, then organization
   summaryView: "summaryView",
   // Show detailed info about a particular person
   detailView: "detailView",
+  // Show results grouped by organization, then location
+  organizationView: "organizationView",
 })
 
 // Initial state for the Redux store. Covers the whole app.


### PR DESCRIPTION
This PR will add 2 new sidebar views to the existing one. After it is merged there will be 3 views:

1. summaryView (the current view): Groups by location and then desc (company or school). Clicking on desc goes to organization view. Clicking on a name goes to detailView
2. organizationView: Groups by desc and then loc. Clicking on locations goes to summaryView. Clicking on a name goes to detailView
3. detailView: Shows information about a person. This view is pretty simple right now and could be significantly improved. Also it doesn't link to any other views.

One potential shortcoming of the current implementation is that switching views (by clicking on stuff in the sidebar) always filters the current data in the sidebar rather than the full dataset. Whether or not this is good UX is hard to tell until we get more data in.