### PR TITLE
Buttons and global search

### DIFF
--- a/static/js/index/components/Sidebar.js
+++ b/static/js/index/components/Sidebar.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Fragment } from "react";
+import Button from 'react-bootstrap/Button';
 import { connect } from "react-redux";
 
 import { sidebarWidthFraction, sidebarHeightFraction } from "../config";
@@ -82,28 +83,48 @@ function createTwoLevelViewJSX(
   };
   return groupedData.map(({ firstKey, secondKeys }, idx) => (
     <Fragment key={idx}>
-      <h5 onClick={() => firstKeyAction(secondKeys)}>
+      <Button
+      onClick={() => firstKeyAction(secondKeys)}
+      variant="primary"
+      size = "lg"
+    >
+      <h5 >
         <b>{firstKey}</b>
       </h5>
+      </Button>
+      <ul>
       {secondKeys.map(({ secondKey, responses }, idx) => (
-        <Fragment key={idx}>
-          <b onClick={() => secondKeyAction(responses)}>{secondKey}</b>
+        <li key={idx}>
+        <Fragment>
+          <Button
+          variant = "outline-primary"
+          size = "sm"
+          onClick={() => secondKeyAction(responses)}>
+            <b> {secondKey}</b>
+          </Button>
+          <ul>
           {responses.map((resp, idx) => (
-            <div
-              key={idx}
-              onClick={() => {
-                store.dispatch({
-                  type: "SHOW_DETAILS",
-                  responses: [resp.idx],
-                  sidebarView: SidebarView.detailView,
-                });
-              }}
-            >
-              {resp.name || "Anonymous"}
-            </div>
+            <li key={idx}>
+              <Button
+                onClick={() => {
+                  store.dispatch({
+                    type: "SHOW_DETAILS",
+                    responses: [resp.idx],
+                    sidebarView: SidebarView.detailView,
+                  });
+                }}
+                variant="outline-secondary"
+                size="sm"
+              >
+                {resp.name || "Anonymous"}
+              </Button>
+            </li>
           ))}
+          </ul>
         </Fragment>
+        </li>
       ))}
+    </ul>
     </Fragment>
   ));
 }

--- a/static/js/index/components/Sidebar.js
+++ b/static/js/index/components/Sidebar.js
@@ -46,116 +46,124 @@ function groupPlansConfigurable(
     }));
 }
 
-function createTwoLevelViewJSX(
-  taggedData,
-  firstKeyView,
-  secondKeyView,
-  firstGroupBy,
-  secondGroupBy,
-) {
-  const groupedData = groupPlansConfigurable(
-    taggedData,
-    firstGroupBy,
-    secondGroupBy,
-  );
-  const firstKeyAction = (secondKeys) => {
-    store.dispatch({
-      type: "SHOW_DETAILS",
-      responses: secondKeys.flatMap((item) =>
-        item.responses.map((resp) => resp.idx),
-      ),
-      sidebarView: firstKeyView,
-    });
-    store.dispatch({
-      type: "UPDATE_MAP_VIEW_ZOOM",
-    });
-  };
-
-  const secondKeyAction = (responses) => {
-    store.dispatch({
-      type: "SHOW_DETAILS",
-      responses: responses.map((resp) => resp.idx),
-      sidebarView: secondKeyView,
-    });
-    store.dispatch({
-      type: "UPDATE_MAP_VIEW_ZOOM",
-    });
-  };
-  return groupedData.map(({ firstKey, secondKeys }, idx) => (
-    <Fragment key={idx}>
-      <Button
-      onClick={() => firstKeyAction(secondKeys)}
-      variant="primary"
-      size = "lg"
-    >
-      <h5 >
-        <b>{firstKey}</b>
-      </h5>
-      </Button>
-      <ul>
-      {secondKeys.map(({ secondKey, responses }, idx) => (
-        <li key={idx}>
-        <Fragment>
-          <Button
-          variant = "outline-primary"
-          size = "sm"
-          onClick={() => secondKeyAction(responses)}>
-            <b> {secondKey}</b>
-          </Button>
-          <ul>
-          {responses.map((resp, idx) => (
-            <li key={idx}>
-              <Button
-                onClick={() => {
-                  store.dispatch({
-                    type: "SHOW_DETAILS",
-                    responses: [resp.idx],
-                    sidebarView: SidebarView.detailView,
-                  });
-                }}
-                variant="outline-secondary"
-                size="sm"
-              >
-                {resp.name || "Anonymous"}
-              </Button>
-            </li>
-          ))}
-          </ul>
-        </Fragment>
-        </li>
-      ))}
-    </ul>
-    </Fragment>
-  ));
-}
-
-function describeSubject(taggedSubject) {
-  let fields = [];
-  if (taggedSubject.tag.desc && taggedSubject.tag.loc) {
-    fields.push(
-      <div>
-        {taggedSubject.tag.desc} in {taggedSubject.tag.loc}
-      </div>,
-    );
-  }
-  if (taggedSubject.major) {
-    fields.push(<div>Majored in {taggedSubject.major}</div>);
-  }
-  if (taggedSubject.comments) {
-    fields.push(<div>Note: {taggedSubject.comments}</div>);
-  }
-  // TODO: Figure out how to cleanly add keys to fields elements
-  return (
-    <div>
-      <h5>
-        <b> {taggedSubject.name}</b>
-      </h5>
-      {fields}
-    </div>
-  );
-}
 
 class Sidebar extends React.Component {
+  doSearch(searchGetter, searchValue, view){
+    store.dispatch({
+      type: "SHOW_DETAILS",
+      responses: this.props.index.filter(resp => (searchGetter(resp) === searchValue)).map(resp => resp.idx),
+      sidebarView: view,
+    });
+    store.dispatch({
+      type: "UPDATE_MAP_VIEW_ZOOM",
+    });
+  };
+
+  createTwoLevelViewJSX(
+    taggedData,
+    firstKeyView,
+    secondKeyView,
+    firstGroupBy,
+    secondGroupBy,
+  ) {
+    const groupedData = groupPlansConfigurable(
+      taggedData,
+      firstGroupBy,
+      secondGroupBy,
+    );
+    return groupedData.map(({ firstKey, secondKeys }, idx) => (
+      <Fragment key={idx}>
+        <Button
+      onClick={
+        () => this.doSearch(firstGroupBy, firstGroupBy(secondKeys[0].responses[0]), firstKeyView)
+      }
+        variant="primary"
+        size = "lg"
+      >
+        <h5 >
+          <b>{firstKey}</b>
+        </h5>
+        </Button>
+        <ul>
+        {secondKeys.map(({ secondKey, responses }, idx) => (
+          <li key={idx}>
+          <Fragment>
+            <Button
+            variant = "outline-primary"
+            size = "sm"
+          onClick={
+            () => this.doSearch(secondGroupBy, secondGroupBy(responses[0]), secondKeyView)
+          }>
+              <b> {secondKey}</b>
+            </Button>
+            <ul>
+            {responses.map((resp, idx) => (
+              <li key={idx}>
+                <Button
+                  onClick={() => {
+                    store.dispatch({
+                      type: "SHOW_DETAILS",
+                      responses: [resp.idx],
+                      sidebarView: SidebarView.detailView,
+                    });
+                  }}
+                  variant="outline-secondary"
+                  size="sm"
+                >
+                  {resp.name || "Anonymous"}
+                </Button>
+              </li>
+            ))}
+            </ul>
+          </Fragment>
+          </li>
+        ))}
+      </ul>
+      </Fragment>
+    ));
+  };
+
+  describeSubject(taggedSubject, index) {
+    let fields = [];
+    if (taggedSubject.tag.desc && taggedSubject.tag.loc) {
+      fields.push(
+        <div>
+          <Button variant="outline-secondary" size="sm" onClick={
+            () => this.doSearch(resp => resp.tag.desc, taggedSubject.tag.desc, SidebarView.organizationView)
+          }>
+          {taggedSubject.tag.desc}
+        </Button>
+          {" in "}
+          <Button variant="outline-secondary" size="sm" onClick={
+            () => this.doSearch(resp => resp.tag.loc, taggedSubject.tag.loc, SidebarView.summaryView)
+          }>
+          {taggedSubject.tag.loc}
+        </Button>
+        </div>,
+      );
+    }
+    if (taggedSubject.major) {
+      fields.push(<div>{"Majored in "}
+                  <Button variant="outline-secondary" size="sm" onClick={
+                    () => this.doSearch(resp => resp.major, taggedSubject.major, SidebarView.summaryView)
+                  }>
+                  {taggedSubject.major}
+                  </Button></div>);
+    }
+    if (taggedSubject.comments) {
+      fields.push(<div>Note: {taggedSubject.comments}</div>);
+    }
+    // TODO: Figure out how to cleanly add keys to fields elements
+    return (
+      <div>
+        <h5>
+          <b> {taggedSubject.name}</b>
+        </h5>
+        {fields}
+      </div>
+    );
+  };
+
   render() {
     let sidebarContent = null;
     const taggedData = tagAll(this.props.responses, this.props.geotagView);
@@ -198,27 +206,29 @@ class Sidebar extends React.Component {
     let sidebarBody = null;
     if (this.props.sidebarView === SidebarView.detailView) {
       const subject = tag(this.props.responses[0], this.props.geotagView);
-      sidebarBody = describeSubject(subject);
+      sidebarBody = this.describeSubject(subject);
     } else {
       // for all view made with createTwoLevelViewJSX
       switch (this.props.sidebarView) {
         case SidebarView.summaryView:
-          sidebarBody = createTwoLevelViewJSX(
+          sidebarBody = this.createTwoLevelViewJSX(
             taggedData,
             SidebarView.summaryView,
             SidebarView.organizationView,
             (resp) => resp.tag.loc,
             (resp) => resp.tag.desc,
+            this.props.index,
           );
           break;
 
         case SidebarView.organizationView:
-          sidebarBody = createTwoLevelViewJSX(
+          sidebarBody = this.createTwoLevelViewJSX(
             taggedData,
             SidebarView.organizationView,
             SidebarView.summaryView,
             (resp) => resp.tag.desc,
             (resp) => resp.tag.loc,
+            this.props.index,
           );
           break;
       }
@@ -229,12 +239,12 @@ class Sidebar extends React.Component {
 
 export default connect((state) => {
   const displayedResponses = new Set(state.displayedResponses);
+  const responses = state.responses.filter((resp) => displayedResponses.has(resp.idx));
   return {
-    responses: state.responses.filter((resp) =>
-      displayedResponses.has(resp.idx),
-    ),
+    responses: responses,
     geotagView: state.geotagView,
     sidebarView: state.sidebarView,
     showVertically: state.landscape,
+    index: responses && tagAll(state.responses, state.geotagView),
   };
 })(Sidebar);

--- a/static/js/index/components/Sidebar.js
+++ b/static/js/index/components/Sidebar.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Fragment } from "react";
-import Button from 'react-bootstrap/Button';
+import Button from "react-bootstrap/Button";
 import { connect } from "react-redux";
 
 import { sidebarWidthFraction, sidebarHeightFraction } from "../config";
@@ -46,18 +46,19 @@ function groupPlansConfigurable(
     }));
 }
 
-
 class Sidebar extends React.Component {
-  doSearch(searchGetter, searchValue, view){
+  doSearch(searchGetter, searchValue, view) {
     store.dispatch({
       type: "SHOW_DETAILS",
-      responses: this.props.index.filter(resp => (searchGetter(resp) === searchValue)).map(resp => resp.idx),
+      responses: this.props.index
+        .filter((resp) => searchGetter(resp) === searchValue)
+        .map((resp) => resp.idx),
       sidebarView: view,
     });
     store.dispatch({
       type: "UPDATE_MAP_VIEW_ZOOM",
     });
-  };
+  }
 
   createTwoLevelViewJSX(
     taggedData,
@@ -74,81 +75,118 @@ class Sidebar extends React.Component {
     return groupedData.map(({ firstKey, secondKeys }, idx) => (
       <Fragment key={idx}>
         <Button
-      onClick={
-        () => this.doSearch(firstGroupBy, firstGroupBy(secondKeys[0].responses[0]), firstKeyView)
-      }
-        variant="primary"
-        size = "lg"
-      >
-        <h5 >
-          <b>{firstKey}</b>
-        </h5>
+          onClick={() =>
+            this.doSearch(
+              firstGroupBy,
+              firstGroupBy(secondKeys[0].responses[0]),
+              firstKeyView,
+            )
+          }
+          variant="primary"
+          size="lg"
+        >
+          <h5>
+            <b>{firstKey}</b>
+          </h5>
         </Button>
         <ul>
-        {secondKeys.map(({ secondKey, responses }, idx) => (
-          <li key={idx}>
-          <Fragment>
-            <Button
-            variant = "outline-primary"
-            size = "sm"
-          onClick={
-            () => this.doSearch(secondGroupBy, secondGroupBy(responses[0]), secondKeyView)
-          }>
-              <b> {secondKey}</b>
-            </Button>
-            <ul>
-            {responses.map((resp, idx) => (
-              <li key={idx}>
+          {secondKeys.map(({ secondKey, responses }, idx) => (
+            <li key={idx}>
+              <Fragment>
                 <Button
-                  onClick={() => {
-                    store.dispatch({
-                      type: "SHOW_DETAILS",
-                      responses: [resp.idx],
-                      sidebarView: SidebarView.detailView,
-                    });
-                  }}
-                  variant="outline-secondary"
+                  variant="outline-primary"
                   size="sm"
+                  onClick={() =>
+                    this.doSearch(
+                      secondGroupBy,
+                      secondGroupBy(responses[0]),
+                      secondKeyView,
+                    )
+                  }
                 >
-                  {resp.name || "Anonymous"}
+                  <b> {secondKey}</b>
                 </Button>
-              </li>
-            ))}
-            </ul>
-          </Fragment>
-          </li>
-        ))}
-      </ul>
+                <ul>
+                  {responses.map((resp, idx) => (
+                    <li key={idx}>
+                      <Button
+                        onClick={() => {
+                          store.dispatch({
+                            type: "SHOW_DETAILS",
+                            responses: [resp.idx],
+                            sidebarView: SidebarView.detailView,
+                          });
+                        }}
+                        variant="outline-secondary"
+                        size="sm"
+                      >
+                        {resp.name || "Anonymous"}
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </Fragment>
+            </li>
+          ))}
+        </ul>
       </Fragment>
     ));
-  };
+  }
 
   describeSubject(taggedSubject, index) {
     let fields = [];
     if (taggedSubject.tag.desc && taggedSubject.tag.loc) {
       fields.push(
         <div>
-          <Button variant="outline-secondary" size="sm" onClick={
-            () => this.doSearch(resp => resp.tag.desc, taggedSubject.tag.desc, SidebarView.organizationView)
-          }>
-          {taggedSubject.tag.desc}
-        </Button>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() =>
+              this.doSearch(
+                (resp) => resp.tag.desc,
+                taggedSubject.tag.desc,
+                SidebarView.organizationView,
+              )
+            }
+          >
+            {taggedSubject.tag.desc}
+          </Button>
           {" in "}
-          <Button variant="outline-secondary" size="sm" onClick={
-            () => this.doSearch(resp => resp.tag.loc, taggedSubject.tag.loc, SidebarView.summaryView)
-          }>
-          {taggedSubject.tag.loc}
-        </Button>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() =>
+              this.doSearch(
+                (resp) => resp.tag.loc,
+                taggedSubject.tag.loc,
+                SidebarView.summaryView,
+              )
+            }
+          >
+            {taggedSubject.tag.loc}
+          </Button>
         </div>,
       );
     }
     if (taggedSubject.major) {
-      fields.push(<div>{"Majored in "}
-                  <Button variant="outline-secondary" size="sm" onClick={
-                    () => this.doSearch(resp => resp.major, taggedSubject.major, SidebarView.summaryView)
-                  }>
-                  {taggedSubject.major}
-                  </Button></div>);
+      fields.push(
+        <div>
+          {"Majored in "}
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() =>
+              this.doSearch(
+                (resp) => resp.major,
+                taggedSubject.major,
+                SidebarView.summaryView,
+              )
+            }
+          >
+            {taggedSubject.major}
+          </Button>
+        </div>,
+      );
     }
     if (taggedSubject.comments) {
       fields.push(<div>Note: {taggedSubject.comments}</div>);
@@ -162,7 +200,7 @@ class Sidebar extends React.Component {
         {fields}
       </div>
     );
-  };
+  }
 
   render() {
     let sidebarContent = null;
@@ -239,7 +277,9 @@ class Sidebar extends React.Component {
 
 export default connect((state) => {
   const displayedResponses = new Set(state.displayedResponses);
-  const responses = state.responses.filter((resp) => displayedResponses.has(resp.idx));
+  const responses = state.responses.filter((resp) =>
+    displayedResponses.has(resp.idx),
+  );
   return {
     responses: responses,
     geotagView: state.geotagView,


### PR DESCRIPTION
This commit adds buttons for all of the clickable fields on the sidebar to make it clear that they can be clicked. It also adds buttons to the results for individual people, and improves the functionality that occurs when clicking on these buttons by making the search across all responses rather than just the ones on the screen. 